### PR TITLE
fix TypeError on py3

### DIFF
--- a/eea/converter/__init__.py
+++ b/eea/converter/__init__.py
@@ -23,7 +23,7 @@ def can_convert_svg():
                     stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                     close_fds=CLOSE_FDS)
     res = process.stdout.read()
-    if 'version' not in res.lower():
+    if 'version' not in str(res.lower()):
         logger.warn(
             ("rsvg-convert NOT FOUND: "
              "ImageMagick will be used to export SVG to PNG images."))
@@ -38,7 +38,7 @@ def can_convert_image():
                     stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                     close_fds=CLOSE_FDS)
     res = process.stdout.read()
-    if 'imagemagick' not in res.lower():
+    if 'imagemagick' not in str(res.lower()):
         logger.warn(
             ("ImageMagick NOT FOUND: "
              "Automatic generation of report's cover image is not supported."))


### PR DESCRIPTION
Fixed TypeError: a bytes-like object is required, not 'str'

Hi I found an error during the installation of the egg in Python3.8

`Traceback (most recent call last):
  File "/srv/webapp/instances/.buildout-cache/eggs/zope.configuration-4.4.0-py3.8.egg/zope/configuration/xmlconfig.py", line 391, in endElementNS
    self.context.end()
  File "/srv/webapp/instances/.buildout-cache/eggs/zope.configuration-4.4.0-py3.8.egg/zope/configuration/config.py", line 704, in end
    self.stack.pop().finish()
  File "/srv/webapp/instances/.buildout-cache/eggs/zope.configuration-4.4.0-py3.8.egg/zope/configuration/config.py", line 869, in finish
    actions = self.handler(context, **args)
  File "/srv/webapp/instances/.buildout-cache/eggs/z3c.autoinclude-0.4.0-py3.8.egg/z3c/autoinclude/zcml.py", line 119, in includePluginsDirective
    info = PluginFinder(dotted_name).includableInfo(zcml_to_look_for)
  File "/srv/webapp/instances/.buildout-cache/eggs/z3c.autoinclude-0.4.0-py3.8.egg/z3c/autoinclude/plugin.py", line 24, in includableInfo
    groups = zcml_to_include(plugin_dottedname, zcml_to_look_for)
  File "/srv/webapp/instances/.buildout-cache/eggs/z3c.autoinclude-0.4.0-py3.8.egg/z3c/autoinclude/plugin.py", line 52, in zcml_to_include
    filename = resource_filename(dotted_name, zcmlgroup)
  File "/srv/webapp/instances/.buildout-cache/eggs/setuptools-42.0.2-py3.8.egg/pkg_resources/__init__.py", line 1144, in resource_filename
    return get_provider(package_or_requirement).get_resource_filename(
  File "/srv/webapp/instances/.buildout-cache/eggs/setuptools-42.0.2-py3.8.egg/pkg_resources/__init__.py", line 361, in get_provider
    __import__(moduleOrReq)
  File "/srv/webapp/instances/.buildout-cache/eggs/eea.converter-12.8-py3.8.egg/eea/converter/__init__.py", line 56, in <module>
    CAN_CONVERT_IMAGE = can_convert_image()
  File "/srv/webapp/instances/.buildout-cache/eggs/eea.converter-12.8-py3.8.egg/eea/converter/__init__.py", line 41, in can_convert_image
    if 'imagemagick' not in res.lower():
TypeError: a bytes-like object is required, not 'str'
`

the error is relative a

`> /srv/webapp/instances/.buildout-cache/eggs/eea.converter-12.8-py3.8.egg/eea/converter/__init__.py(27)can_convert_svg()
-> if 'version' not in res.lower():
(Pdb) res
b'rsvg-convert version 2.48.7\n'
(Pdb) res.lower()
b'rsvg-convert version 2.48.7\n'
(Pdb) 'version' not in res.lower()
*** TypeError: a bytes-like object is required, not 'str'
`

because 

`process = Popen('rsvg-convert --version', shell=True,
                    stdin=PIPE, stdout=PIPE, stderr=STDOUT,
                    close_fds=CLOSE_FDS)
 res = process.stdout.read()`

return a byte string in py3